### PR TITLE
/api/<route> prefix, get_user_model() in UserSerializer

### DIFF
--- a/kubeportal/api/serializers.py
+++ b/kubeportal/api/serializers.py
@@ -1,7 +1,7 @@
-from kubeportal.models import User
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
-        model = User
-        fields = ('username',)
+        model = get_user_model()
+        fields = ('id', 'username', 'first_name', 'last_name', 'email')

--- a/kubeportal/urls.py
+++ b/kubeportal/urls.py
@@ -23,6 +23,5 @@ urlpatterns = [
     path('admin/', admin_site.urls),
     # Note: The OpenID Connect URL is /oidc/authorize
     path('oidc/', include('oidc_provider.urls', namespace='oidc_provider')),
+    path('api/', include(router.urls), name='api')
 ]
-
-urlpatterns += router.urls


### PR DESCRIPTION
- switched all api routes behind the /api/<route> prefix
￼- get_user_model() in UserSerializer, added some fields